### PR TITLE
Helper Data getConversion return 1

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -77,7 +77,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             }
         }
 
-        return 0;
+        return 1;
     }
 
     /**


### PR DESCRIPTION
When unit reference and unit product are same.
Per default there is no configuration when unit are same btw the reference and the product one. For this reason the conversion value returned is 0 although it should 1 as there are the same. It will be too long to create a configuration for all of them and it doesn't make sense.