### PR TITLE
Update Data.php to fix BasePrice on config Product

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -126,6 +126,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getBasePrice(\Magento\Catalog\Model\Product $product)
     {
         $productPrice = $product->getFinalPrice();
+        
+        if ($product->getTypeId() == "configurable")
+            $productPrice = $product->getPriceInfo()->getPrice('final_price')->getValue();
+
         $conversion = $this->getConversion($product);
         $referenceAmount = $product->getData('baseprice_reference_amount');
         $productAmount = $product->getData('baseprice_product_amount');


### PR DESCRIPTION
Magneto deliver different prices for $product->getFinalPrice() or $product->getPriceInfo()->getPrice('final_price')->getValue();
The Problem is for config products on getFinalPrice the "Dummy" price of parent is delivert and not the minimum price of the children.
"Dummy" price means when you create an config product you have to set an price for the parent because it is an requiered field. Normaly the "Dummy" price  is not shown on frontend.