### PR TITLE
Remove php dependency from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
   "name": "magenerds/baseprice",
   "description": "This module displays base prices",
   "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0|7.0.2|7.0.4|~7.0.6|~7.1.0",
     "magento/framework": "100.1.*|101.0.0",
     "magenerds/dashboard": "^1.0"
   },


### PR DESCRIPTION
The php requirement is not needed because the php version is derived from the magento/framework which has it's own dependency on php. The magenerds/baseprice package should only be well tested with the specified version magento/framework.