### PR TITLE
Replace native serialize function with abstract serializer

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -34,6 +34,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     protected $_priceHelper;
 
     /**
+     * @var \Magento\Framework\Serialize\SerializerInterface
+     */
+    private $_serializer;
+
+    /**
      * Constructor
      *
      * @param \Magento\Framework\App\Helper\Context $context
@@ -41,9 +46,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
-        \Magento\Framework\Pricing\Helper\Data $priceHelper
+        \Magento\Framework\Pricing\Helper\Data $priceHelper,
+        \Magento\Framework\Serialize\SerializerInterface $serializer
     ){
         $this->_priceHelper = $priceHelper;
+        $this->_serializer = $serializer;
         parent::__construct($context);
     }
 
@@ -58,7 +65,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $productUnit = $product->getData('baseprice_product_unit');
         $referenceUnit = $product->getData('baseprice_reference_unit');
 
-        $configArray = unserialize($this->scopeConfig->getValue(
+        $configArray = $this->_serializer->unserialize($this->scopeConfig->getValue(
             self::CONVERSION_CONFIG_PATH,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         ));

--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -49,6 +49,11 @@ class InstallData implements InstallDataInterface
     protected $_eavConfig;
 
     /**
+     * @var \Magento\Framework\Serialize\SerializerInterface
+     */
+    private $_serializer;
+
+    /**
      * Constructor
      *
      * @param \Magento\Eav\Setup\EavSetupFactory $eavSetupFactory
@@ -60,12 +65,14 @@ class InstallData implements InstallDataInterface
         \Magento\Eav\Setup\EavSetupFactory $eavSetupFactory,
         \Magento\Catalog\Api\ProductAttributeOptionManagementInterface $productAttributeOptionManagementInterface,
         \Magento\Config\Model\ResourceModel\Config $configResource,
-        \Magento\Eav\Model\Config $eavConfig
+        \Magento\Eav\Model\Config $eavConfig,
+        \Magento\Framework\Serialize\SerializerInterface $serializer
     ){
         $this->_eavSetupFactory = $eavSetupFactory;
         $this->_productAttributeOptionManagementInterface = $productAttributeOptionManagementInterface;
         $this->_configResource = $configResource;
         $this->_eavConfig = $eavConfig;
+        $this->_serializer = $serializer;
     }
 
     /**
@@ -268,7 +275,7 @@ class InstallData implements InstallDataInterface
         // save system configuration
         $this->_configResource->saveConfig(
             \Magenerds\BasePrice\Helper\Data::CONVERSION_CONFIG_PATH,
-            serialize($data),
+            $this->_serializer->serialize($data),
             \Magento\Framework\App\Config\ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
             0
         );


### PR DESCRIPTION
Fixes #23

Instead using native serialize function, the fix implements the usage of the serializer interface.
I've tested at a real project. Works fine.

This fix does not include backward compatibility which would look like:

1. On module upgrade get the value via unserialize function
2. save the value via the serializer interface 

Steps to install the fixed module:

1. Delete the module from the database
`DELETE FROM `setup_module` WHERE `setup_module`.`module` = 'Magenerds_BasePrice'`
2. Delete cache
php bin/magento cache:clean
3. Install module
php bin/magento setup:upgrade