### PR TITLE
Fix productAmount calculation

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -148,7 +148,7 @@ class Data extends AbstractHelper
         $productAmount = $product->getData('baseprice_product_amount');
 
         $basePrice = 0;
-        if ($productPrice && $conversion && $referenceAmount && $productAmount) {
+        if ($productPrice && $conversion && $referenceAmount && $productAmount && $productAmount > 0) {
             $basePrice = $productPrice * $conversion * $referenceAmount / $productAmount;
         }
 


### PR DESCRIPTION
Added check for `$productAmount > 0`. We had an issue with the `$productAmount` variable being a floating point number and the check at line 151 evaluated to `true` and we got a warning for a division by zero.