### PR TITLE
Base prices for tier prices

### DIFF
--- a/Block/AfterPrice.php
+++ b/Block/AfterPrice.php
@@ -99,4 +99,13 @@ class AfterPrice extends \Magento\Framework\View\Element\Template
     {
         return $this->_helper->getBasePriceText($this->getProduct());
     }
+
+    /**
+     * Returns the base price for tier prices
+     * @return array
+     */
+    public function getTierBasePrices(): array
+    {
+        return $this->_helper->getTierBasePricesText($this->getProduct(), true);
+    }
 }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -18,7 +18,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magenerds_BasePrice" setup_version="1.0.4">
+    <module name="Magenerds_BasePrice" setup_version="1.1.0">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_Eav"/>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -18,7 +18,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magenerds_BasePrice" setup_version="1.1.0">
+    <module name="Magenerds_BasePrice" setup_version="1.0.4">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_Eav"/>


### PR DESCRIPTION
This pr adds the ability to get an array with the base prices for all tier prices of a product. This array can then be rendered in a template to show the base price after the template. I did not include a modified template in this pr because this would override the base Magento template which can have a lot of unwanted side effects. I'll leave that up to the developer using this plugin.