### PR TITLE
Fixed blank page for backend configuration

### DIFF
--- a/Block/Adminhtml/Form/Field/Unit.php
+++ b/Block/Adminhtml/Form/Field/Unit.php
@@ -61,8 +61,11 @@ class Unit extends \Magento\Framework\View\Element\Html\Select
     {
         if (!$this->getOptions()) {
             $this->addOption('', __('-- Select value --'));
-            foreach ($this->_productAttributeOptionManagementInterface->getItems($this->_attributeCode) as $item) {
-                $this->addOption($item->getValue(), $item->getLabel());
+            foreach ($this->_eavConfig->getAttribute('catalog_product', 'baseprice_product_unit')->getSource()->getAllOptions() as $item) {
+                if (empty($item['value']) || empty($item['label'])) {
+                    continue;
+                }
+                $this->addOption($item['value'], $item['label']);
             }
         }
         return parent::_toHtml();


### PR DESCRIPTION
The productAttributeOptionManagementInterface doesn't return the custom attribute anymore, which results in a blank page. Not the best solution, but a temporary one that works.

#48 